### PR TITLE
Sam patch 3

### DIFF
--- a/.github/workflows/gpcp.yml
+++ b/.github/workflows/gpcp.yml
@@ -19,7 +19,11 @@ jobs:
           script: |
               module use /g/data/hh5/public/modules
               module load conda/analysis3
+              
               cd /g/data/ia39/aus-ref-clim-data-nci/gpcp/code
               yr=$(date +'%Y')
+              
               python gpcp.py -y $yr >> update_log.txt
               python gpcp.py -y $yr -t monthly >> update_log.txt
+
+              bash gpcp_concat.sh -y $yr

--- a/.github/workflows/gpcp.yml
+++ b/.github/workflows/gpcp.yml
@@ -20,6 +20,6 @@ jobs:
               module use /g/data/hh5/public/modules
               module load conda/analysis3
               cd /g/data/ia39/aus-ref-clim-data-nci/gpcp/code
-              yr=2023
+              yr=$(date +'%Y')
               python gpcp.py -y $yr >> update_log.txt
               python gpcp.py -y $yr -t monthly >> update_log.txt

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # GPCP
 
+![workflow](https://github.com/aus-ref-clim-data-nci/GPCP/actions/workflows/gpcp.yml/badge.svg)
+
 ## Overview
 
 The Global Precipitation Climatology Project (GPCP),

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To see all the options:
 python gpcp.py --help
 ```
 
-Weekly updates are managed via the [Jenkins accessdev server](https://accessdev.nci.org.au/jenkins/job/aus-ref-clim-data-nci/job/GPCC/).
+Weekly updates are managed via the [GitHub Action](https://github.com/aus-ref-clim-data-nci/GPCP/actions/workflows/gpcp.yml).
 
 
 ## Data location
@@ -63,6 +63,14 @@ then this is indicated in the filenames as in this example:
 ```
 gpcp_v02r03-preliminary_monthly_d201908_c20190910.nc
 ```
+
+We've now concatenate the V1-3 daily data into a yearly file, they are located at:
+
+```
+/g/data/ia39/aus-ref-clim-data-nci/gpcp/data/day_concat/<files>
+```
+Files are in netcdf4 format and filenames are `gpcp_v01r03_daily_YYYY.nc` for v1.3 daily.
+
 
 ## License
 


### PR DESCRIPTION
Adding script to concatenate the daily data into yearly files as per issue #2, these are located at: "/g/data/ia39/aus-ref-clim-data-nci/gpcp/data/day_concat/".

Updated the workflow script to run on the current year and to also concatenate the latest daily data into the current year file.

Updated part of the Readme to add the above info, also added a badge to make it easier to see if the data Action has been working or not.